### PR TITLE
NOISSUE - Optimized Docker build, split into stages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,13 @@ ARG TIME
 WORKDIR /go/src/github.com/ultravioletrs/cocos-ai
 COPY . .
 RUN apk update \
-    && apk add make qemu-system-x86_64 \
+    && apk add make \
     && make $SVC \
     && mv build/cocos-$SVC /exe
+
+FROM alpine:latest
+RUN apk add qemu-system-x86_64
+COPY --from=builder /exe /
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ENTRYPOINT ["/exe"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -5,4 +5,3 @@ COPY cocos-$SVC /exe
 COPY --from=alpine:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ENTRYPOINT ["/exe"]
-


### PR DESCRIPTION
Refactored the Dockerfile to use multi-stage builds, improving the image size and separation of concerns. Removed `qemu-system-x86_64` from the initial build stage and included it in a new, minimal final image based on `alpine:latest`. 