### PR TITLE
COCOS-7 - Switch qemu config to use kernel and initrd images

### DIFF
--- a/manager/qemu/config.go
+++ b/manager/qemu/config.go
@@ -139,11 +139,11 @@ func constructQemuArgs(config Config) []string {
 			config.VirtioScsiPciConfig.DisableLegacy,
 			config.VirtioScsiPciConfig.IOMMUPlatform))
 
-	args = append(args, "-kernel", fmt.Sprintf("%s", config.DiskImgConfig.KernelFile))
+	args = append(args, "-kernel", config.DiskImgConfig.KernelFile)
 
 	args = append(args, "-append", "earlyprintk=serial console=ttyS0")
 
-	args = append(args, "-initrd", fmt.Sprintf("%s", config.DiskImgConfig.RootFsFile))
+	args = append(args, "-initrd", config.DiskImgConfig.RootFsFile)
 
 	// network
 	args = append(args, "-netdev",

--- a/manager/qemu/config.go
+++ b/manager/qemu/config.go
@@ -42,10 +42,8 @@ type VirtioNetPciConfig struct {
 }
 
 type DiskImgConfig struct {
-	File   string `env:"DISK_IMG_FILE" envDefault:"img/focal-server-cloudimg-amd64.img"`
-	If     string `env:"DISK_IMG_IF" envDefault:"none"`
-	ID     string `env:"DISK_IMG_ID" envDefault:"disk0"`
-	Format string `env:"DISK_IMG_FORMAT" envDefault:"qcow2"`
+	KernelFile string `env:"DISK_IMG_KERNEL_FILE" envDefault:"img/bzImage"`
+	RootFsFile string `env:"DISK_IMG_ROOTFS_FILE" envDefault:"img/rootfs.cpio.gz"`
 }
 
 type VirtioScsiPciConfig struct {
@@ -141,15 +139,11 @@ func constructQemuArgs(config Config) []string {
 			config.VirtioScsiPciConfig.DisableLegacy,
 			config.VirtioScsiPciConfig.IOMMUPlatform))
 
-	args = append(args, "-drive",
-		fmt.Sprintf("file=%s,if=%s,id=%s,format=%s",
-			config.DiskImgConfig.File,
-			config.DiskImgConfig.If,
-			config.DiskImgConfig.ID,
-			config.DiskImgConfig.Format))
+	args = append(args, "-kernel", fmt.Sprintf("%s", config.DiskImgConfig.KernelFile))
 
-	args = append(args, "-device",
-		fmt.Sprintf("scsi-hd,drive=%s", config.DiskImgConfig.ID))
+	args = append(args, "-append", "earlyprintk=serial console=ttyS0")
+
+	args = append(args, "-initrd", fmt.Sprintf("%s", config.DiskImgConfig.RootFsFile))
 
 	// network
 	args = append(args, "-netdev",

--- a/manager/qemu/qemu.go
+++ b/manager/qemu/qemu.go
@@ -19,7 +19,7 @@ const (
 )
 
 func CreateVM(ctx context.Context, cfg Config) (*exec.Cmd, error) {
-	// create unique emu device identifiers
+	// Create unique emu device identifiers.
 	id, err := uuid.NewV4()
 	if err != nil {
 		return &exec.Cmd{}, err
@@ -29,7 +29,7 @@ func CreateVM(ctx context.Context, cfg Config) (*exec.Cmd, error) {
 	qemuCfg.VirtioScsiPciConfig.ID = fmt.Sprintf("%s-%s", qemuCfg.VirtioScsiPciConfig.ID, id)
 	qemuCfg.SevConfig.ID = fmt.Sprintf("%s-%s", qemuCfg.SevConfig.ID, id)
 
-	// copy firmware vars file
+	// Copy firmware vars file.
 	srcFile := qemuCfg.OVMFVarsConfig.File
 	dstFile := fmt.Sprintf("%s/%s-%s.fd", cfg.TmpFileLoc, firmwareVars, id)
 	err = internal.CopyFile(srcFile, dstFile)
@@ -38,7 +38,7 @@ func CreateVM(ctx context.Context, cfg Config) (*exec.Cmd, error) {
 	}
 	qemuCfg.OVMFVarsConfig.File = dstFile
 
-	// copy img files
+	// Copy img files.
 	srcFile = qemuCfg.DiskImgConfig.KernelFile
 	dstFile = fmt.Sprintf("%s/%s-%s", cfg.TmpFileLoc, KernelFile, id)
 	err = internal.CopyFile(srcFile, dstFile)


### PR DESCRIPTION
Refactored qemu configuration to load the system using separate kernel and initial ramdisk images instead of a QCOW2 image. Removed previous disk image configurations and replaced them with directives to specify the kernel (`bzImage`) and root filesystem (`rootfs.cpio.gz`) files. Adjusted the constructQemuArgs function accordingly to set the kernel path, kernel command line options, and initrd path. Updated CreateVM function to handle copying of the new kernel and rootfs images. 

Documentation will be updated after #20 
Resolves #7 