### PR TITLE
NOISSUE - Enhanced gRPC server concurrency with errgroup

### DIFF
--- a/manager/api/grpc/server.go
+++ b/manager/api/grpc/server.go
@@ -59,5 +59,4 @@ func (s *grpcServer) Process(stream manager.ManagerService_ProcessServer) error 
 		return nil
 	})
 	return eg.Wait()
-
 }

--- a/manager/api/grpc/server.go
+++ b/manager/api/grpc/server.go
@@ -3,7 +3,10 @@
 package grpc
 
 import (
+	"context"
+
 	"github.com/ultravioletrs/cocos/manager"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/peer"
 )
 
@@ -11,36 +14,50 @@ type grpcServer struct {
 	manager.UnimplementedManagerServiceServer
 	incoming chan *manager.ClientStreamMessage
 	svc      Service
+	ctx      context.Context
 }
 
 type Service interface {
-	Run(ipAddress string) manager.ComputationRunReq
+	Run(ipAddress string, runReqChan chan *manager.ComputationRunReq)
 }
 
 // NewServer returns new AuthServiceServer instance.
-func NewServer(incoming chan *manager.ClientStreamMessage, svc Service) manager.ManagerServiceServer {
+func NewServer(ctx context.Context, incoming chan *manager.ClientStreamMessage, svc Service) manager.ManagerServiceServer {
 	return &grpcServer{
 		incoming: incoming,
 		svc:      svc,
+		ctx:      ctx,
 	}
 }
 
 func (s *grpcServer) Process(stream manager.ManagerService_ProcessServer) error {
-	for {
-		req, err := stream.Recv()
-		if err != nil {
-			return err
-		}
-		if _, ok := req.Message.(*manager.ClientStreamMessage_Whoami); ok {
-			client, ok := peer.FromContext(stream.Context())
-			if ok {
-				req := s.svc.Run(client.Addr.String())
-				if err := stream.Send(&req); err != nil {
-					return err
+	eg, _ := errgroup.WithContext(s.ctx)
+	runReqChan := make(chan *manager.ComputationRunReq)
+	eg.Go(func() error {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				return err
+			}
+			if _, ok := req.Message.(*manager.ClientStreamMessage_Whoami); ok {
+				client, ok := peer.FromContext(stream.Context())
+				if ok {
+					s.svc.Run(client.Addr.String(), runReqChan)
 				}
 			}
-		}
 
-		s.incoming <- req
-	}
+			s.incoming <- req
+		}
+	})
+
+	eg.Go(func() error {
+		for runReq := range runReqChan {
+			if err := stream.Send(runReq); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return eg.Wait()
+
 }


### PR DESCRIPTION
Refactored the gRPC server's `Process` method to handle incoming messages and service execution concurrently using an `errgroup.Group`. Added a context to the `grpcServer` struct and propagated it to support graceful shutdowns and better request handling. Changed the `Service` interface's `Run` method to use a channel for transmitting `ComputationRunReq`, facilitating non-blocking operation and streamlining the request-response cycle.

Asynchronous handling of stream requests with `errgroup` allows simultaneous processing and error management, improving the server's responsiveness and fault tolerance. This update paves the way for more robust service implementations that require concurrent operations.