### PR TITLE
NOISSUE - Enforce 32-byte length check for hashes

### DIFF
--- a/manager/service.go
+++ b/manager/service.go
@@ -18,6 +18,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+const hashLength = 32
+
 var (
 	// ErrMalformedEntity indicates malformed entity specification (e.g.
 	// invalid username or password).
@@ -83,14 +85,14 @@ func (ms *managerService) Run(ctx context.Context, c *manager.ComputationRunReq)
 		},
 	}
 	for _, algo := range c.Algorithms {
-		if len(algo.Hash) != 32 {
+		if len(algo.Hash) != hashLength {
 			ms.publishEvent("vm-provision", c.Id, "failed", json.RawMessage{})
 			return "", errInvalidHashLength
 		}
 		ac.Algorithms = append(ac.Algorithms, agent.Algorithm{ID: algo.Id, Provider: algo.Provider, Hash: [32]byte(algo.Hash)})
 	}
 	for _, data := range c.Datasets {
-		if len(data.Hash) != 32 {
+		if len(data.Hash) != hashLength {
 			ms.publishEvent("vm-provision", c.Id, "failed", json.RawMessage{})
 			return "", errInvalidHashLength
 		}

--- a/manager/service.go
+++ b/manager/service.go
@@ -32,6 +32,8 @@ var (
 
 	// ErrFailedToAllocatePort indicates no free port was found on host.
 	ErrFailedToAllocatePort = errors.New("failed to allocate free port on host")
+
+	errInvalidHashLength = errors.New("hash must be of byte length 32")
 )
 
 // Service specifies an API that must be fulfilled by the domain service
@@ -81,9 +83,17 @@ func (ms *managerService) Run(ctx context.Context, c *manager.ComputationRunReq)
 		},
 	}
 	for _, algo := range c.Algorithms {
+		if len(algo.Hash) < 32 {
+			ms.publishEvent("vm-provision", c.Id, "failed", json.RawMessage{})
+			return "", errInvalidHashLength
+		}
 		ac.Algorithms = append(ac.Algorithms, agent.Algorithm{ID: algo.Id, Provider: algo.Provider, Hash: [32]byte(algo.Hash)})
 	}
 	for _, data := range c.Datasets {
+		if len(data.Hash) < 32 {
+			ms.publishEvent("vm-provision", c.Id, "failed", json.RawMessage{})
+			return "", errInvalidHashLength
+		}
 		ac.Datasets = append(ac.Datasets, agent.Dataset{ID: data.Id, Provider: data.Provider, Hash: [32]byte(data.Hash)})
 	}
 

--- a/manager/service.go
+++ b/manager/service.go
@@ -89,14 +89,14 @@ func (ms *managerService) Run(ctx context.Context, c *manager.ComputationRunReq)
 			ms.publishEvent("vm-provision", c.Id, "failed", json.RawMessage{})
 			return "", errInvalidHashLength
 		}
-		ac.Algorithms = append(ac.Algorithms, agent.Algorithm{ID: algo.Id, Provider: algo.Provider, Hash: [32]byte(algo.Hash)})
+		ac.Algorithms = append(ac.Algorithms, agent.Algorithm{ID: algo.Id, Provider: algo.Provider, Hash: [hashLength]byte(algo.Hash)})
 	}
 	for _, data := range c.Datasets {
 		if len(data.Hash) != hashLength {
 			ms.publishEvent("vm-provision", c.Id, "failed", json.RawMessage{})
 			return "", errInvalidHashLength
 		}
-		ac.Datasets = append(ac.Datasets, agent.Dataset{ID: data.Id, Provider: data.Provider, Hash: [32]byte(data.Hash)})
+		ac.Datasets = append(ac.Datasets, agent.Dataset{ID: data.Id, Provider: data.Provider, Hash: [hashLength]byte(data.Hash)})
 	}
 
 	agentPort, err := getFreePort()

--- a/manager/service.go
+++ b/manager/service.go
@@ -83,14 +83,14 @@ func (ms *managerService) Run(ctx context.Context, c *manager.ComputationRunReq)
 		},
 	}
 	for _, algo := range c.Algorithms {
-		if len(algo.Hash) < 32 {
+		if len(algo.Hash) != 32 {
 			ms.publishEvent("vm-provision", c.Id, "failed", json.RawMessage{})
 			return "", errInvalidHashLength
 		}
 		ac.Algorithms = append(ac.Algorithms, agent.Algorithm{ID: algo.Id, Provider: algo.Provider, Hash: [32]byte(algo.Hash)})
 	}
 	for _, data := range c.Datasets {
-		if len(data.Hash) < 32 {
+		if len(data.Hash) != 32 {
 			ms.publishEvent("vm-provision", c.Id, "failed", json.RawMessage{})
 			return "", errInvalidHashLength
 		}

--- a/test/manager-server/main.go
+++ b/test/manager-server/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"log"
 	"log/slog"
@@ -33,12 +34,13 @@ type svc struct {
 
 func (s *svc) Run(ipAdress string, reqChan chan *manager.ComputationRunReq) {
 	s.logger.Debug(fmt.Sprintf("received who am on ip address %s", ipAdress))
+	hash := sha256.Sum256([]byte("test"))
 	reqChan <- &manager.ComputationRunReq{
 		Id:              "1",
 		Name:            "sample computation",
 		Description:     "sample descrption",
-		Datasets:        []*manager.Dataset{{Id: "1", Provider: "provider1"}},
-		Algorithms:      []*manager.Algorithm{{Id: "1", Provider: "provider1"}},
+		Datasets:        []*manager.Dataset{{Id: "1", Provider: "provider1", Hash: hash[:]}},
+		Algorithms:      []*manager.Algorithm{{Id: "1", Provider: "provider1", Hash: hash[:]}},
 		ResultConsumers: []string{"consumer1"},
 		AgentConfig: &manager.AgentConfig{
 			Port:     "7002",


### PR DESCRIPTION
Introduced a validation step in the manager service to ensure both algorithm and dataset hashes are of byte length 32 before provisioning VMs, preventing runtime errors due to invalid hash lengths. The test manager-server now generates a valid 32-byte hash using SHA256 for mock data to align with the new validation requirement.