### PR TITLE
NOISSUE - Introduced standard GitHub templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug Report
+description: File a bug/issue report. Make sure to search to see if an issue already exists for the bug you encountered.
+title: "Bug: <title>"
+labels: ["bug", "needs-review", "help wanted"]
+body:
+  - type: textarea
+    attributes:
+      label: What were you trying to achieve?
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What are the expected results?
+      description: A concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What are the received results?
+      description: A concise description of what you received.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: What are the steps to reproduce the issue?
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: In what environment did you encounter the issue?
+      description: A concise description of the environment you encountered the issue in.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information you deem important
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: File a feature request. Make sure to search to see if a request already exists for the feature you are requesting.
+title: "Feature: <title>"
+labels: ["enchancement", "needs-review"]
+body:
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the feature you are requesting, as well as the possible use case(s) for it.
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Indicate the importance of this feature to you.
+      description: This will help us prioritize the feature request.
+      options:
+        - Must-have
+        - Should-have
+        - Nice-to-have
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the feature that you are requesting.
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,66 @@
+<!--
+
+Pull request title should be `COCOS-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
+Please review the [CONTRIBUTING.md](https://github.com/ultravioletrs/cocos/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
+
+For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
+
+For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.
+
+- Provide tests for your changes.
+- Use descriptive commit messages.
+- Comment your code where appropriate.
+- Squash your commits
+- Update any related documentation.
+-->
+
+# What type of PR is this?
+
+<!--This represents the type of PR you are submitting.
+
+For example:
+This is a bug fix because it fixes the following issue: #1234
+This is a feature because it adds the following functionality: ...
+This is a refactor because it changes the following functionality: ...
+This is a documentation update because it updates the following documentation: ...
+This is a dependency update because it updates the following dependencies: ...
+This is an optimization because it improves the following functionality: ...
+-->
+
+## What does this do?
+
+<!--
+Please provide a brief description of what this PR is intended to do.
+Include List any changes that modify/break current functionality.
+-->
+
+## Which issue(s) does this PR fix/relate to?
+
+<!--
+For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
+-->
+
+- Related Issue #
+- Resolves #
+
+## Have you included tests for your changes?
+
+<!--If you have not included tests, please explain why.
+For example:
+Yes, I have included tests for my changes.
+No, I have not included tests because I do not know how to.
+-->
+
+## Did you document any new/modified feature?
+
+<!--If you have not included documentation, please explain why.
+For example:
+Yes, I have updated the documentation for the new feature.
+No, I have not updated the documentation because I do not know how to.
+-->
+
+### Notes
+
+<!--Please provide any additional information you feel is important.-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to CoCos
+
+The following is a set of guidelines to contribute to CoCos and its libraries, which are
+hosted on the [Ultraviolet Organization](https://github.com/ultravioletrs) on GitHub.
+
+This project adheres to the [Contributor Covenant 1.2](http://contributor-covenant.org/version/1/2/0).
+By participating, you are expected to uphold this code. Please report unacceptable behavior to
+[abuse@ultraviolet.rs](mailto:abuse@ultraviolet.rs).
+
+## Reporting issues
+
+Reporting issues are a great way to contribute to the project. We are perpetually grateful about a well-written,
+thorough bug report.
+
+Before raising a new issue, check [our issue
+list](https://github.com/ultravioletrs/cocos/issues) to determine if it already contains the
+problem that you are facing.
+
+A good bug report shouldn't leave others needing to chase you for more information. Please be as detailed as possible. The following questions might serve as a template for writing a detailed
+report:
+
+- What were you trying to achieve?
+- What are the expected results?
+- What are the received results?
+- What are the steps to reproduce the issue?
+- In what environment did you encounter the issue?
+
+## Pull requests
+
+Good pull requests (e.g. patches, improvements, new features) are a fantastic help. They should
+remain focused in scope and avoid unrelated commits.
+
+**Please ask first** before embarking on any significant pull request (e.g. implementing new features,
+refactoring code etc.), otherwise you risk spending a lot of time working on something that the
+maintainers might not want to merge into the project.
+
+Please adhere to the coding conventions used throughout the project. If in doubt, consult the
+[Effective Go](https://golang.org/doc/effective_go.html) style guide.
+
+To contribute to the project, [fork](https://help.github.com/articles/fork-a-repo/) it,
+clone your fork repository, and configure the remotes:
+
+```
+git clone https://github.com/<your-username>/cocos.git
+cd cocos
+git remote add upstream https://github.com/ultravioletrs/cocos.git
+```
+
+If your cloned repository is behind the upstream commits, then get the latest changes from upstream:
+
+```
+git checkout master
+git pull --rebase upstream main
+```
+
+Create a new topic branch from `master` using the naming convention `COCOS-[issue-number]`
+to help us keep track of your contribution scope:
+
+```
+git checkout -b COCOS-[issue-number]
+```
+
+Commit your changes in logical chunks. When you are ready to commit, make sure
+to write a Good Commit Message™. Consult the [Erlang's contributing guide](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
+if you're unsure of what constitutes a Good Commit Message™. Use [interactive rebase](https://help.github.com/articles/about-git-rebase)
+to group your commits into logical units of work before making it public.
+
+Note that every commit you make must be signed. By signing off your work you indicate that you
+are accepting the [Developer Certificate of Origin](https://developercertificate.org/).
+
+Use your real name (sorry, no pseudonyms or anonymous contributions). If you set your `user.name`
+and `user.email` git configs, you can sign your commit automatically with `git commit -s`.
+
+Locally merge (or rebase) the upstream development branch into your topic branch:
+
+```
+git pull --rebase upstream main
+```
+
+Push your topic branch up to your fork:
+
+```
+git push origin COCOS-[issue-number]
+```
+
+[Open a Pull Request](https://help.github.com/articles/using-pull-requests/) with a clear title
+and detailed description.


### PR DESCRIPTION
Implemented new GitHub templates to streamline the contribution process. Bug report and feature request templates guide users in creating detailed and actionable issues, while a universal pull request template ensures systematically structured submissions. These additions facilitate more efficient reviews, and prioritize issues effectively. Additionally, configured the repository to disallow blank issues, encouraging use of the templates for better project management.