### PR TITLE
NOISSUE - Fix network interface problem for agent

### DIFF
--- a/manager/qemu/config.go
+++ b/manager/qemu/config.go
@@ -149,13 +149,9 @@ func constructQemuArgs(config Config) []string {
 			config.VirtioNetPciConfig.ROMFile))
 
 	args = append(args, "-device", fmt.Sprintf("vhost-vsock-pci,id=%s,guest-cid=%d", config.VSockConfig.ID, config.VSockConfig.GuestCID))
-
 	args = append(args, "-vnc", fmt.Sprintf(":%d", config.vnc))
-
 	args = append(args, "-kernel", config.DiskImgConfig.KernelFile)
-
 	args = append(args, "-append", strconv.Quote("earlyprintk=serial console=ttyS0"))
-
 	args = append(args, "-initrd", config.DiskImgConfig.RootFsFile)
 
 	// SEV

--- a/manager/qemu/config.go
+++ b/manager/qemu/config.go
@@ -37,7 +37,6 @@ type NetDevConfig struct {
 type VirtioNetPciConfig struct {
 	DisableLegacy string `env:"VIRTIO_NET_PCI_DISABLE_LEGACY" envDefault:"on"`
 	IOMMUPlatform bool   `env:"VIRTIO_NET_PCI_IOMMU_PLATFORM" envDefault:"true"`
-	Bus           string `env:"VIRTIO_NET_PCI_BUS" envDefault:"pcie.0"`
 	Addr          string `env:"VIRTIO_NET_PCI_ADDR" envDefault:"0x2"`
 	ROMFile       string `env:"VIRTIO_NET_PCI_ROMFILE"`
 }
@@ -142,11 +141,10 @@ func constructQemuArgs(config Config) []string {
 			config.NetDevConfig.HostFwdAgent, config.NetDevConfig.GuestFwdAgent))
 
 	args = append(args, "-device",
-		fmt.Sprintf("virtio-net-pci,disable-legacy=%s,iommu_platform=%v,netdev=%s,bus=%s,addr=%s,romfile=%s",
+		fmt.Sprintf("virtio-net-pci,disable-legacy=%s,iommu_platform=%v,netdev=%s,addr=%s,romfile=%s",
 			config.VirtioNetPciConfig.DisableLegacy,
 			config.VirtioNetPciConfig.IOMMUPlatform,
 			config.NetDevConfig.ID,
-			config.VirtioNetPciConfig.Bus,
 			config.VirtioNetPciConfig.Addr,
 			config.VirtioNetPciConfig.ROMFile))
 

--- a/manager/qemu/config.go
+++ b/manager/qemu/config.go
@@ -47,12 +47,6 @@ type DiskImgConfig struct {
 	RootFsFile string `env:"DISK_IMG_ROOTFS_FILE" envDefault:"img/rootfs.cpio.gz"`
 }
 
-type VirtioScsiPciConfig struct {
-	ID            string `env:"VIRTIO_SCSI_PCI_ID" envDefault:"scsi"`
-	DisableLegacy string `env:"VIRTIO_SCSI_PCI_DISABLE_LEGACY" envDefault:"on"`
-	IOMMUPlatform bool   `env:"VIRTIO_SCSI_PCI_IOMMU_PLATFORM" envDefault:"true"`
-}
-
 type SevConfig struct {
 	ID              string `env:"SEV_ID" envDefault:"sev0"`
 	CBitPos         int    `env:"SEV_CBITPOS" envDefault:"51"`
@@ -91,7 +85,6 @@ type Config struct {
 	VSockConfig
 
 	// disk
-	VirtioScsiPciConfig
 	DiskImgConfig
 
 	// SEV
@@ -156,13 +149,6 @@ func constructQemuArgs(config Config) []string {
 			config.VirtioNetPciConfig.Bus,
 			config.VirtioNetPciConfig.Addr,
 			config.VirtioNetPciConfig.ROMFile))
-
-	// disk
-	args = append(args, "-device",
-		fmt.Sprintf("virtio-scsi-pci,id=%s,disable-legacy=%s,iommu_platform=%t",
-			config.VirtioScsiPciConfig.ID,
-			config.VirtioScsiPciConfig.DisableLegacy,
-			config.VirtioScsiPciConfig.IOMMUPlatform))
 
 	args = append(args, "-device", fmt.Sprintf("vhost-vsock-pci,id=%s,guest-cid=%d", config.VSockConfig.ID, config.VSockConfig.GuestCID))
 

--- a/manager/qemu/qemu.go
+++ b/manager/qemu/qemu.go
@@ -26,7 +26,6 @@ func CreateVM(ctx context.Context, cfg Config) (*exec.Cmd, error) {
 	}
 	qemuCfg := cfg
 	qemuCfg.NetDevConfig.ID = fmt.Sprintf("%s-%s", qemuCfg.NetDevConfig.ID, id)
-	qemuCfg.VirtioScsiPciConfig.ID = fmt.Sprintf("%s-%s", qemuCfg.VirtioScsiPciConfig.ID, id)
 	qemuCfg.SevConfig.ID = fmt.Sprintf("%s-%s", qemuCfg.SevConfig.ID, id)
 
 	// Copy firmware vars file.


### PR DESCRIPTION
<!--

Pull request title should be `COCOS-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/ultravioletrs/cocos/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is a fix for agent networking interface problem and removes SCSI parameter from the QEMU command (or SCSI interface from the VM).
<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
The problem was that the agent could not connect to the network, because the network interface did not have the default (expected) name. The name is given to the network interface by `systemd` based on the network type (ethernet, WLAN etc.), slot number etc. 

Also, the `virtio-scsi-pci` parameter is removed from the QEMU command, because we no longer have a virtual disk for the VM.
<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to? 
No issue
<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

## Have you included tests for your changes?
The Manager and the Manager test server should be up and running (look at the manager README file). When the VM is started, the `cli` tool should be used.
<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->

## Did you document any new/modified feature?
Documentation will be updated when the whole flow is tested.
<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes

<!--Please provide any additional information you feel is important.-->
