### PR TITLE
COCOS-145 : Support Other Private/Public Key Pair Algorithms

### DIFF
--- a/agent/auth/auth.go
+++ b/agent/auth/auth.go
@@ -114,14 +114,11 @@ func verifySignature(role UserRole, signature string, publicKey any) error {
 		if err = rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, hash[:], sigByte); err != nil {
 			return err
 		}
+		return nil
 	case *ecdsa.PublicKey:
 		ok = ecdsa.VerifyASN1(publicKey, hash[:], sigByte)
 	case ed25519.PublicKey:
-		ok = ed25519.Verify(publicKey, hash[:], sigByte)
-	}
-	
-	if err != nil {
-		return err
+		ok = ed25519.Verify(publicKey, []byte(role), sigByte)
 	}
 
 	if !ok {

--- a/agent/auth/auth.go
+++ b/agent/auth/auth.go
@@ -6,6 +6,8 @@ package auth
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -29,7 +31,6 @@ const (
 )
 
 var (
-	errNotRSAPublicKey             = errors.New("not an RSA public key")
 	ErrMissingMetadata             = errors.New("missing metadata")
 	ErrInvalidMetadata             = errors.New("invalid metadata")
 	ErrSignatureVerificationFailed = errors.New("signature verification failed")
@@ -41,9 +42,9 @@ type Authenticator interface {
 }
 
 type service struct {
-	resultConsumers   []*rsa.PublicKey
-	datasetProviders  []*rsa.PublicKey
-	algorithmProvider *rsa.PublicKey
+	resultConsumers   []interface{}
+	datasetProviders  []interface{}
+	algorithmProvider interface{}
 }
 
 func New(manifest agent.Computation) (Authenticator, error) {
@@ -54,12 +55,12 @@ func New(manifest agent.Computation) (Authenticator, error) {
 			return nil, err
 		}
 
-		rsaPubKey, ok := pubKey.(*rsa.PublicKey)
-		if !ok {
-			return nil, errNotRSAPublicKey
+		pKey, err := decodePublicKey(pubKey)
+		if err != nil {
+			return nil, err
 		}
 
-		s.resultConsumers = append(s.resultConsumers, rsaPubKey)
+		s.resultConsumers = append(s.resultConsumers, pKey)
 	}
 
 	for _, dp := range manifest.Datasets {
@@ -68,12 +69,12 @@ func New(manifest agent.Computation) (Authenticator, error) {
 			return nil, err
 		}
 
-		rsaPubKey, ok := pubKey.(*rsa.PublicKey)
-		if !ok {
-			return nil, errNotRSAPublicKey
+		pKey, err := decodePublicKey(pubKey)
+		if err != nil {
+			return nil, err
 		}
 
-		s.datasetProviders = append(s.datasetProviders, rsaPubKey)
+		s.datasetProviders = append(s.datasetProviders, pKey)
 	}
 
 	pubKey, err := x509.ParsePKIXPublicKey(manifest.Algorithm.UserKey)
@@ -81,12 +82,12 @@ func New(manifest agent.Computation) (Authenticator, error) {
 		return nil, err
 	}
 
-	rsaPubKey, ok := pubKey.(*rsa.PublicKey)
-	if !ok {
-		return nil, errNotRSAPublicKey
+	pKey, err := decodePublicKey(pubKey)
+	if err != nil {
+		return nil, err
 	}
 
-	s.algorithmProvider = rsaPubKey
+	s.algorithmProvider = pKey
 	return s, nil
 }
 
@@ -99,16 +100,34 @@ func extractSignature(md metadata.MD) (string, error) {
 	return signature[0], nil
 }
 
-func verifySignature(role UserRole, signature string, publicKey *rsa.PublicKey) error {
+func verifySignature(role UserRole, signature string, publicKey any) error {
 	hash := sha256.Sum256([]byte(role))
 	sigByte, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {
 		return err
 	}
 
-	if err := rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, hash[:], sigByte); err != nil {
+	var ok bool
+
+	switch publicKey := publicKey.(type) {
+	case *rsa.PublicKey:
+		if err = rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, hash[:], sigByte); err != nil {
+			return err
+		}
+	case *ecdsa.PublicKey:
+		ok = ecdsa.VerifyASN1(publicKey, hash[:], sigByte)
+	case ed25519.PublicKey:
+		ok = ed25519.Verify(publicKey, hash[:], sigByte)
+	}
+	
+	if err != nil {
 		return err
 	}
+
+	if !ok {
+		return ErrSignatureVerificationFailed
+	}
+
 	return nil
 }
 
@@ -142,4 +161,17 @@ func (s *service) AuthenticateUser(ctx context.Context, role UserRole) (context.
 	}
 
 	return ctx, ErrSignatureVerificationFailed
+}
+
+func decodePublicKey(key any) (pubKey any, err error) {
+	switch key := key.(type) {
+	case *rsa.PublicKey:
+		return key, nil
+	case *ecdsa.PublicKey:
+		return key, nil
+	case ed25519.PublicKey:
+		return key, nil
+	default:
+		return nil, errors.New("unsupported public key type")
+	}
 }

--- a/cli/algorithms.go
+++ b/cli/algorithms.go
@@ -3,13 +3,21 @@
 package cli
 
 import (
+	"crypto/ed25519"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"log"
 	"os"
 
+	mgerr "github.com/absmach/magistrala/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/ultravioletrs/cocos/agent"
+)
+
+var (
+	errParseECP = errors.New("x509: failed to parse private key (use ParseECPrivateKey instead for this key format)")
+	errParsePKC = errors.New("x509: failed to parse private key (use ParsePKCS1PrivateKey instead for this key format)")
 )
 
 func (cli *CLI) NewAlgorithmCmd() *cobra.Command {
@@ -39,13 +47,35 @@ func (cli *CLI) NewAlgorithmCmd() *cobra.Command {
 
 			pemBlock, _ := pem.Decode(privKeyFile)
 
-			privKey, err := x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
-			if err != nil {
-				log.Fatalf("Error parsing private key: %v", err)
-			}
+			bytes, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
+			switch {
+			case mgerr.Contains(err, errParsePKC):
+				privKey, err := x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
+				if err != nil {
+					log.Fatalf("Error parsing private key: %v", err)
+				}
+				if err := cli.agentSDK.Algo(cmd.Context(), algoReq, privKey); err != nil {
+					log.Fatalf("Error uploading algorithm with error: %v", err)
+				}
+			case mgerr.Contains(err, errParseECP):
+				privKey, err := x509.ParseECPrivateKey(pemBlock.Bytes)
+				if err != nil {
+					log.Fatalf("Error parsing private key: %v", err)
+				}
+				if err := cli.agentSDK.Algo(cmd.Context(), algoReq, privKey); err != nil {
+					log.Fatalf("Error uploading algorithm with error: %v", err)
+				}
+			case err == nil:
+				ed25519Key, ok := bytes.(ed25519.PrivateKey)
+				if !ok {
+					log.Fatalf("Error parsing private key: %v", err)
+				}
 
-			if err := cli.agentSDK.Algo(cmd.Context(), algoReq, privKey); err != nil {
-				log.Fatalf("Error uploading algorithm with error: %v", err)
+				if err := cli.agentSDK.Algo(cmd.Context(), algoReq, ed25519Key); err != nil {
+					log.Fatalf("Error uploading algorithm with error: %v", err)
+				}
+			default:
+				log.Fatalf("Error reading private key file: %v", err)
 			}
 
 			log.Println("Successfully uploaded algorithm")

--- a/cli/algorithms.go
+++ b/cli/algorithms.go
@@ -3,21 +3,13 @@
 package cli
 
 import (
-	"crypto/ed25519"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"log"
 	"os"
 
-	mgerr "github.com/absmach/magistrala/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/ultravioletrs/cocos/agent"
-)
-
-var (
-	errParseECP = errors.New("x509: failed to parse private key (use ParseECPrivateKey instead for this key format)")
-	errParsePKC = errors.New("x509: failed to parse private key (use ParsePKCS1PrivateKey instead for this key format)")
 )
 
 func (cli *CLI) NewAlgorithmCmd() *cobra.Command {
@@ -47,17 +39,19 @@ func (cli *CLI) NewAlgorithmCmd() *cobra.Command {
 
 			pemBlock, _ := pem.Decode(privKeyFile)
 
-			bytes, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
-			switch {
-			case mgerr.Contains(err, errParsePKC):
-				privKey, err := x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
+			switch pemBlock.Type {
+			case rsaKeyType:
+				privKey, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
 				if err != nil {
-					log.Fatalf("Error parsing private key: %v", err)
+					privKey, err = x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
+					if err != nil {
+						log.Fatalf("Error parsing private key: %v", err)
+					}
 				}
 				if err := cli.agentSDK.Algo(cmd.Context(), algoReq, privKey); err != nil {
 					log.Fatalf("Error uploading algorithm with error: %v", err)
 				}
-			case mgerr.Contains(err, errParseECP):
+			case ecdsaKeyType:
 				privKey, err := x509.ParseECPrivateKey(pemBlock.Bytes)
 				if err != nil {
 					log.Fatalf("Error parsing private key: %v", err)
@@ -65,17 +59,8 @@ func (cli *CLI) NewAlgorithmCmd() *cobra.Command {
 				if err := cli.agentSDK.Algo(cmd.Context(), algoReq, privKey); err != nil {
 					log.Fatalf("Error uploading algorithm with error: %v", err)
 				}
-			case err == nil:
-				ed25519Key, ok := bytes.(ed25519.PrivateKey)
-				if !ok {
-					log.Fatalf("Error parsing private key: %v", err)
-				}
-
-				if err := cli.agentSDK.Algo(cmd.Context(), algoReq, ed25519Key); err != nil {
-					log.Fatalf("Error uploading algorithm with error: %v", err)
-				}
 			default:
-				log.Fatalf("Error reading private key file: %v", err)
+				log.Fatalf("ssh: unsupported key type %q", pemBlock.Type)
 			}
 
 			log.Println("Successfully uploaded algorithm")

--- a/cli/keys.go
+++ b/cli/keys.go
@@ -3,19 +3,25 @@
 package cli
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"log"
 	"os"
+	"reflect"
 
 	"github.com/spf13/cobra"
 )
 
 const (
 	keyBitSize     = 4096
-	privateKeyType = "RSA PRIVATE KEY"
+	rsaKeyType     = "PRIVATE KEY"
+	ecdsaKeyType   = "EC PRIVATE KEY"
+	ed25519KeyType = "PRIVATE KEY"
 	publicKeyType  = "PUBLIC KEY"
 	publicKeyFile  = "public.pem"
 	privateKeyFile = "private.pem"
@@ -23,46 +29,99 @@ const (
 
 func (cli *CLI) NewKeysCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "keys",
+		Use:   "keys <algorithm>",
 		Short: "Generate a new public/private key pair",
+		Long: "Generates a new public/private key pair using an algorithm of the users choice.\n" +
+			"Supported algorithms are RSA, ecdsa, and ed25519.",
+		Example: "./build/cocos-cli keys rsa",
+		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			privKey, err := rsa.GenerateKey(rand.Reader, keyBitSize)
-			if err != nil {
-				log.Fatalf("Error generating public key: %v", err)
-			}
+			switch args[0] {
+			case "ecdsa":
+				privEcdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					log.Fatalf("Error generating keys: %v", err)
+				}
 
-			pubKey, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
-			if err != nil {
-				log.Fatalf("Error marshalling public key: %v", err)
-			}
+				pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privEcdsaKey.PublicKey)
+				if err != nil {
+					log.Fatalf("Error marshalling public key: %v", err)
+				}
 
-			privFile, err := os.Create(privateKeyFile)
-			if err != nil {
-				log.Fatalf("Error creating private key file: %v", err)
-			}
-			defer privFile.Close()
+				generateAndWriteKeys(privEcdsaKey, pubKeyBytes, ecdsaKeyType)
 
-			if err := pem.Encode(privFile, &pem.Block{
-				Type:  privateKeyType,
-				Bytes: x509.MarshalPKCS1PrivateKey(privKey),
-			}); err != nil {
-				log.Fatalf("Error encoding private key: %v", err)
-			}
+			case "ed25519":
+				pubEd25519Key, privEd25519Key, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					log.Fatalf("Error generating keys: %v", err)
+				}
+				pubKey, err := x509.MarshalPKIXPublicKey(pubEd25519Key)
+				if err != nil {
+					log.Fatalf("Error marshalling public key: %v", err)
+				}
+				generateAndWriteKeys(privEd25519Key, pubKey, ed25519KeyType)
 
-			pubFile, err := os.Create(publicKeyFile)
-			if err != nil {
-				log.Fatalf("Error creating public key file: %v", err)
-			}
-			defer pubFile.Close()
+			// Default to RSA
+			default:
+				privKey, err := rsa.GenerateKey(rand.Reader, keyBitSize)
+				if err != nil {
+					log.Fatalf("Error generating keys: %v", err)
+				}
 
-			if err := pem.Encode(pubFile, &pem.Block{
-				Type:  publicKeyType,
-				Bytes: pubKey,
-			}); err != nil {
-				log.Fatalf("Error encoding public key: %v", err)
-			}
+				pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+				if err != nil {
+					log.Fatalf("Error marshalling public key: %v", err)
+				}
 
-			log.Println("Successfully generated public/private key pair")
+				generateAndWriteKeys(privKey, pubKeyBytes, rsaKeyType)
+			}
 		},
 	}
+}
+
+func generateAndWriteKeys(privKey interface{}, pubKeyBytes []byte, keyType string) {
+	privFile, err := os.Create(privateKeyFile)
+	if err != nil {
+		log.Fatalf("Error creating private key file: %v", err)
+	}
+	defer privFile.Close()
+
+	var b []byte
+	switch privKey := privKey.(type) {
+	case *rsa.PrivateKey:
+		b = x509.MarshalPKCS1PrivateKey(privKey)
+	case *ecdsa.PrivateKey:
+		b, err = x509.MarshalECPrivateKey(privKey)
+	case ed25519.PrivateKey:
+		b, err = x509.MarshalPKCS8PrivateKey(privKey)
+	}
+	if err != nil {
+		log.Printf("Error marshalling private key: %v", err)
+		return
+	}
+
+	if err := pem.Encode(privFile, &pem.Block{
+		Type:  keyType,
+		Bytes: b,
+	}); err != nil {
+		log.Printf("Error encoding private key: %v", err)
+		return
+	}
+
+	pubFile, err := os.Create(publicKeyFile)
+	if err != nil {
+		log.Printf("Error creating public key file: %v", err)
+		return
+	}
+	defer pubFile.Close()
+
+	if err := pem.Encode(pubFile, &pem.Block{
+		Type:  publicKeyType,
+		Bytes: pubKeyBytes,
+	}); err != nil {
+		log.Printf("Error encoding public key: %v", err)
+		return
+	}
+
+	log.Printf("Successfully generated public/private key pair of type: %s", reflect.TypeOf(privKey).String())
 }

--- a/cli/keys.go
+++ b/cli/keys.go
@@ -27,16 +27,18 @@ const (
 	privateKeyFile = "private.pem"
 )
 
+var KeyType string
+
 func (cli *CLI) NewKeysCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "keys <algorithm>",
+		Use:   "keys",
 		Short: "Generate a new public/private key pair",
 		Long: "Generates a new public/private key pair using an algorithm of the users choice.\n" +
 			"Supported algorithms are RSA, ecdsa, and ed25519.",
-		Example: "./build/cocos-cli keys rsa",
-		Args:    cobra.ExactArgs(1),
+		Example: "./build/cocos-cli keys -k rsa",
+		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			switch args[0] {
+			switch KeyType {
 			case "ecdsa":
 				privEcdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 				if err != nil {
@@ -72,7 +74,6 @@ func (cli *CLI) NewKeysCmd() *cobra.Command {
 				if err != nil {
 					log.Fatalf("Error marshalling public key: %v", err)
 				}
-
 				generateAndWriteKeys(privKey, pubKeyBytes, rsaKeyType)
 			}
 		},

--- a/cli/result.go
+++ b/cli/result.go
@@ -3,13 +3,11 @@
 package cli
 
 import (
-	"crypto/ed25519"
 	"crypto/x509"
 	"encoding/pem"
 	"log"
 	"os"
 
-	mgerr "github.com/absmach/magistrala/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -32,34 +30,26 @@ func (cli *CLI) NewResultsCmd() *cobra.Command {
 			pemBlock, _ := pem.Decode(privKeyFile)
 
 			var result []byte
-			bytes, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
-			switch {
-			case mgerr.Contains(err, errParsePKC):
-				privKey, err := x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
-				if err != nil {
-					log.Fatalf("Error parsing private key: %v", err)
-				}
 
+			switch pemBlock.Type {
+			case rsaKeyType:
+				privKey, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
+				if err != nil {
+					privKey, err = x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
+					if err != nil {
+						log.Fatalf("Error parsing private key: %v", err)
+					}
+				}
 				result, err = cli.agentSDK.Result(cmd.Context(), privKey)
 				if err != nil {
 					log.Fatalf("Error retrieving computation result: %v", err)
 				}
-			case mgerr.Contains(err, errParseECP):
+			case ecdsaKeyType:
 				privKey, err := x509.ParseECPrivateKey(pemBlock.Bytes)
 				if err != nil {
 					log.Fatalf("Error parsing private key: %v", err)
 				}
 				result, err = cli.agentSDK.Result(cmd.Context(), privKey)
-				if err != nil {
-					log.Fatalf("Error retrieving computation result: %v", err)
-				}
-			case err == nil:
-				ed25519Key, ok := bytes.(ed25519.PrivateKey)
-				if !ok {
-					log.Fatalf("Error parsing private key: %v", err)
-				}
-
-				result, err = cli.agentSDK.Result(cmd.Context(), ed25519Key)
 				if err != nil {
 					log.Fatalf("Error retrieving computation result: %v", err)
 				}

--- a/cli/result.go
+++ b/cli/result.go
@@ -3,11 +3,13 @@
 package cli
 
 import (
+	"crypto/ed25519"
 	"crypto/x509"
 	"encoding/pem"
 	"log"
 	"os"
 
+	mgerr "github.com/absmach/magistrala/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -29,16 +31,41 @@ func (cli *CLI) NewResultsCmd() *cobra.Command {
 
 			pemBlock, _ := pem.Decode(privKeyFile)
 
-			privKey, err := x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
-			if err != nil {
-				log.Fatalf("Error parsing private key: %v", err)
-			}
+			var result []byte
+			bytes, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
+			switch {
+			case mgerr.Contains(err, errParsePKC):
+				privKey, err := x509.ParsePKCS1PrivateKey(pemBlock.Bytes)
+				if err != nil {
+					log.Fatalf("Error parsing private key: %v", err)
+				}
 
-			result, err := cli.agentSDK.Result(cmd.Context(), privKey)
-			if err != nil {
-				log.Fatalf("Error retrieving computation result: %v", err)
-			}
+				result, err = cli.agentSDK.Result(cmd.Context(), privKey)
+				if err != nil {
+					log.Fatalf("Error retrieving computation result: %v", err)
+				}
+			case mgerr.Contains(err, errParseECP):
+				privKey, err := x509.ParseECPrivateKey(pemBlock.Bytes)
+				if err != nil {
+					log.Fatalf("Error parsing private key: %v", err)
+				}
+				result, err = cli.agentSDK.Result(cmd.Context(), privKey)
+				if err != nil {
+					log.Fatalf("Error retrieving computation result: %v", err)
+				}
+			case err == nil:
+				ed25519Key, ok := bytes.(ed25519.PrivateKey)
+				if !ok {
+					log.Fatalf("Error parsing private key: %v", err)
+				}
 
+				result, err = cli.agentSDK.Result(cmd.Context(), ed25519Key)
+				if err != nil {
+					log.Fatalf("Error retrieving computation result: %v", err)
+				}
+			default:
+				log.Fatalf("Error reading private key file: %v", err)
+			}
 			if err := os.WriteFile(resultFilePath, result, 0o644); err != nil {
 				log.Fatalf("Error saving computation result to %s: %v", resultFilePath, err)
 			}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -100,15 +100,17 @@ func main() {
 		},
 	}
 
+	keysCmd := cliSVC.NewKeysCmd()
+	attestationCmd := cliSVC.NewAttestationCmd()
+
 	// Agent Commands
 	rootCmd.AddCommand(cliSVC.NewAlgorithmCmd())
 	rootCmd.AddCommand(cliSVC.NewDatasetsCmd())
 	rootCmd.AddCommand(cliSVC.NewResultsCmd())
-	attestationCmd := cliSVC.NewAttestationCmd()
 	rootCmd.AddCommand(attestationCmd)
 	rootCmd.AddCommand(cliSVC.NewFileHashCmd())
 	rootCmd.AddCommand(cliSVC.NewAddMeasurementCmd())
-	rootCmd.AddCommand(cliSVC.NewKeysCmd())
+	rootCmd.AddCommand(keysCmd)
 	rootCmd.AddCommand(cliSVC.NewCABundleCmd(directoryCachePath))
 
 	// Attestation commands
@@ -116,7 +118,7 @@ func main() {
 	attestationCmd.AddCommand(cliSVC.NewValidateAttestationValidationCmd())
 
 	// Flags
-	rootCmd.PersistentFlags().StringVarP(
+	keysCmd.PersistentFlags().StringVarP(
 		&cli.KeyType,
 		"key-type",
 		"k",

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -104,16 +104,25 @@ func main() {
 	rootCmd.AddCommand(cliSVC.NewAlgorithmCmd())
 	rootCmd.AddCommand(cliSVC.NewDatasetsCmd())
 	rootCmd.AddCommand(cliSVC.NewResultsCmd())
-	attestaionCmd := cliSVC.NewAttestationCmd()
-	rootCmd.AddCommand(attestaionCmd)
+	attestationCmd := cliSVC.NewAttestationCmd()
+	rootCmd.AddCommand(attestationCmd)
 	rootCmd.AddCommand(cliSVC.NewFileHashCmd())
 	rootCmd.AddCommand(cliSVC.NewAddMeasurementCmd())
 	rootCmd.AddCommand(cliSVC.NewKeysCmd())
 	rootCmd.AddCommand(cliSVC.NewCABundleCmd(directoryCachePath))
 
 	// Attestation commands
-	attestaionCmd.AddCommand(cliSVC.NewGetAttestationCmd())
-	attestaionCmd.AddCommand(cliSVC.NewValidateAttestationValidationCmd())
+	attestationCmd.AddCommand(cliSVC.NewGetAttestationCmd())
+	attestationCmd.AddCommand(cliSVC.NewValidateAttestationValidationCmd())
+
+	// Flags
+	rootCmd.PersistentFlags().StringVarP(
+		&cli.KeyType,
+		"key-type",
+		"k",
+		"rsa",
+		"User Key type",
+	)
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.Error(fmt.Sprintf("Command execution failed: %s", err))


### PR DESCRIPTION
# What type of PR is this?

This is a feature because it adds support for other Public/Private key pair types.

## What does this do?

This adds the following private/public key pair types in addition to the already existing RSA:

- ecdsa
- ed25519

The PR allows generation of these keys, and modifies sdk to accept multiple key types to be used as digital signatures for agent.

## Which issue(s) does this PR fix/relate to?

- Resolves #145

## Have you included tests for your changes?

No

## Did you document any new/modified feature?

No
