### PR TITLE
COCOS-168 - Allow Computations With No Datasets To Run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ cmd/manager/tmp
 .cov
 
 *.pem
+
+dist/
+result.bin
+*.spec

--- a/agent/service.go
+++ b/agent/service.go
@@ -87,12 +87,6 @@ func New(ctx context.Context, logger *slog.Logger, eventSvc events.Service, cmp 
 	svc.sm.StateFunctions[complete] = svc.publishEvent("in-progress", json.RawMessage{})
 	svc.sm.StateFunctions[running] = svc.runComputation
 
-	if len(cmp.Datasets) == 0 {
-		svc.sm.StateFunctions[receivingData] = func() {
-			svc.sm.SendEvent(dataReceived)
-		}
-	}
-
 	svc.computation = cmp
 	svc.sm.SendEvent(manifestReceived)
 	return svc
@@ -130,6 +124,11 @@ func (as *agentService) Algo(ctx context.Context, algorithm Algorithm) error {
 	}
 
 	as.algorithm = f.Name()
+
+	if len(as.computation.Datasets) == 0 {
+		as.sm.SendEvent(algoReceivedNoData)
+		return nil
+	}
 
 	if as.algorithm != "" {
 		as.sm.SendEvent(algorithmReceived)

--- a/agent/service.go
+++ b/agent/service.go
@@ -125,6 +125,10 @@ func (as *agentService) Algo(ctx context.Context, algorithm Algorithm) error {
 
 	as.algorithm = f.Name()
 
+	if len(as.computation.Datasets) == 0 {
+		as.sm.SendEvent(dataReceived)
+	}
+
 	if as.algorithm != "" {
 		as.sm.SendEvent(algorithmReceived)
 	}

--- a/agent/service.go
+++ b/agent/service.go
@@ -87,6 +87,12 @@ func New(ctx context.Context, logger *slog.Logger, eventSvc events.Service, cmp 
 	svc.sm.StateFunctions[complete] = svc.publishEvent("in-progress", json.RawMessage{})
 	svc.sm.StateFunctions[running] = svc.runComputation
 
+	if len(cmp.Datasets) == 0 {
+		svc.sm.StateFunctions[receivingData] = func() {
+			svc.sm.SendEvent(dataReceived)
+		}
+	}
+
 	svc.computation = cmp
 	svc.sm.SendEvent(manifestReceived)
 	return svc
@@ -124,10 +130,6 @@ func (as *agentService) Algo(ctx context.Context, algorithm Algorithm) error {
 	}
 
 	as.algorithm = f.Name()
-
-	if len(as.computation.Datasets) == 0 {
-		as.sm.SendEvent(dataReceived)
-	}
 
 	if as.algorithm != "" {
 		as.sm.SendEvent(algorithmReceived)

--- a/agent/service.go
+++ b/agent/service.go
@@ -73,7 +73,7 @@ var _ Service = (*agentService)(nil)
 // New instantiates the agent service implementation.
 func New(ctx context.Context, logger *slog.Logger, eventSvc events.Service, cmp Computation) Service {
 	svc := &agentService{
-		sm:       NewStateMachine(logger),
+		sm:       NewStateMachine(logger, cmp),
 		eventSvc: eventSvc,
 	}
 
@@ -124,11 +124,6 @@ func (as *agentService) Algo(ctx context.Context, algorithm Algorithm) error {
 	}
 
 	as.algorithm = f.Name()
-
-	if len(as.computation.Datasets) == 0 {
-		as.sm.SendEvent(algoReceivedNoData)
-		return nil
-	}
 
 	if as.algorithm != "" {
 		as.sm.SendEvent(algorithmReceived)

--- a/agent/state.go
+++ b/agent/state.go
@@ -10,7 +10,7 @@ import (
 )
 
 //go:generate stringer -type=state
-type state int
+type state uint8
 
 const (
 	idle state = iota
@@ -22,7 +22,7 @@ const (
 	complete
 )
 
-type event int
+type event uint8
 
 const (
 	start event = iota
@@ -63,6 +63,7 @@ func NewStateMachine(logger *slog.Logger) *StateMachine {
 
 	sm.Transitions[receivingAlgorithm] = make(map[event]state)
 	sm.Transitions[receivingAlgorithm][algorithmReceived] = receivingData
+	sm.Transitions[receivingAlgorithm][dataReceived] = running
 
 	sm.Transitions[receivingData] = make(map[event]state)
 	sm.Transitions[receivingData][dataReceived] = running

--- a/agent/state.go
+++ b/agent/state.go
@@ -28,6 +28,7 @@ const (
 	start event = iota
 	manifestReceived
 	algorithmReceived
+	algoReceivedNoData
 	dataReceived
 	runComplete
 	resultsConsumed
@@ -63,7 +64,7 @@ func NewStateMachine(logger *slog.Logger) *StateMachine {
 
 	sm.Transitions[receivingAlgorithm] = make(map[event]state)
 	sm.Transitions[receivingAlgorithm][algorithmReceived] = receivingData
-	sm.Transitions[receivingAlgorithm][dataReceived] = running
+	sm.Transitions[receivingAlgorithm][algoReceivedNoData] = running
 
 	sm.Transitions[receivingData] = make(map[event]state)
 	sm.Transitions[receivingData][dataReceived] = running

--- a/agent/state_test.go
+++ b/agent/state_test.go
@@ -19,7 +19,7 @@ func TestStateMachineTransitions(t *testing.T) {
 		{idle, start, receivingManifest},
 		{receivingManifest, manifestReceived, receivingAlgorithm},
 		{receivingAlgorithm, algorithmReceived, receivingData},
-		{receivingAlgorithm, dataReceived, running},
+		{receivingAlgorithm, algoReceivedNoData, running},
 		{receivingData, dataReceived, running},
 		{running, runComplete, resultsReady},
 		{resultsReady, resultsConsumed, complete},

--- a/agent/state_test.go
+++ b/agent/state_test.go
@@ -19,6 +19,7 @@ func TestStateMachineTransitions(t *testing.T) {
 		{idle, start, receivingManifest},
 		{receivingManifest, manifestReceived, receivingAlgorithm},
 		{receivingAlgorithm, algorithmReceived, receivingData},
+		{receivingAlgorithm, dataReceived, running},
 		{receivingData, dataReceived, running},
 		{running, runComplete, resultsReady},
 		{resultsReady, resultsConsumed, complete},

--- a/test/manual/algo/addition.py
+++ b/test/manual/algo/addition.py
@@ -1,0 +1,24 @@
+import sys, io
+import joblib
+import socket
+
+a = 5
+b = 10
+result = a + b
+
+buffer = io.BytesIO()
+joblib.dump(result, buffer)
+
+data = buffer.getvalue()
+
+socket_path = sys.argv[1]
+
+client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+try:
+    client.connect(socket_path)
+
+    client.send(data)
+
+finally:
+    client.close()

--- a/test/manual/algo/addition.py
+++ b/test/manual/algo/addition.py
@@ -2,23 +2,75 @@ import sys, io
 import joblib
 import socket
 
-a = 5
-b = 10
-result = a + b
+class Computation:
+    result = 0
+    def __init__(self):
+        """
+        Initializes a new instance of the Computation class.
+        """
+        pass
 
-buffer = io.BytesIO()
-joblib.dump(result, buffer)
+    def compute(self, a, b):
+        """
+        Computes the sum of two numbers.
+        """
+        self.result = a + b
 
-data = buffer.getvalue()
+    def send_result(self, socket_path):
+        """
+        Sends the result to a socket.
+        """
+        buffer = io.BytesIO()
+        
+        try:
+            joblib.dump(self.result, buffer)
+        except Exception as e:
+            print("Failed to dump the result to the buffer: ", e)
+            return
 
-socket_path = sys.argv[1]
+        data = buffer.getvalue()
 
-client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            try:
+                client.connect(socket_path)
+            except Exception as e:
+                print("Failed to connect to the socket: ", e)
+                return
+            try:
+                client.send(data)
+            except Exception as e:
+                print("Failed to send data to the socket: ", e)
+                return
+        finally:
+            client.close()
+    
+    def read_results_from_file(self, results_file):
+        """
+        Reads the results from a file.
+        """
+        try:
+            results = joblib.load(results_file)
+            print("Results: ", results)
+        except Exception as e:
+            print("Failed to load results from file: ", e)
+            return
 
-try:
-    client.connect(socket_path)
+if __name__ == "__main__":
+    a = 5
+    b = 10
+    computation = Computation()
 
-    client.send(data)
+    if len(sys.argv) == 1:
+        print("Please provide a socket path or a file path")
+        exit(1)
+    
+    if sys.argv[1] == "test" and len(sys.argv) == 3:
+        computation.read_results_from_file(sys.argv[2])
+    elif len(sys.argv) == 2:
+        computation.compute(a, b)
+        computation.send_result(sys.argv[1])
+    else:
+        print("Invalid arguments")
+        exit(1)
 
-finally:
-    client.close()

--- a/test/manual/algo/addition_test.py
+++ b/test/manual/algo/addition_test.py
@@ -1,8 +1,0 @@
-import sys
-import joblib
-
-results_file = sys.argv[1]
-
-results = joblib.load(results_file)
-
-print("Results: ", results)

--- a/test/manual/algo/addition_test.py
+++ b/test/manual/algo/addition_test.py
@@ -1,0 +1,8 @@
+import sys
+import joblib
+
+results_file = sys.argv[1]
+
+results = joblib.load(results_file)
+
+print("Results: ", results)


### PR DESCRIPTION
# What type of PR is this?

This is a feature because it adds running computation when dataset is empty

## What does this do?

The updates enable state-machine transitions from the `receivingAlgorithm` state to the `running` state if no dataset is provided.

## Which issue(s) does this PR fix/relate to?

- Resolves #168 

## Have you included tests for your changes?

Yes, I have included tests for my changes.

## Did you document any new/modified feature?

No need for documentation since this is an expected scenario

### Notes

- **Refactor**
  - Updated state machine transitions to improve control flow.

- **Bug Fixes**
  - Changed types from `int` to `uint8` for state and event to prevent possible overflows.

- **Tests**
  - Modified tests to reflect new state machine transitions and event handling.
  
```mermaid
sequenceDiagram
    participant User
    participant Agent
    participant StateMachine
    User->>Agent: Provide Algorithm
    Note right of Agent: Checking dataset length
    alt Dataset length is 0
        Agent->>StateMachine: Send algoReceivedNoData event
        StateMachine->>StateMachine: Transition to running state
    else Dataset length > 0
        Agent->>StateMachine: Send algorithmReceived event
        StateMachine->>StateMachine: Transition to receivingAlgorithm state
    end
    StateMachine->>User: Acknowledge state transition
```