### PR TITLE
NOISSUE - Allow Computation With Empty Dataset

### DIFF
--- a/test/computations/main.go
+++ b/test/computations/main.go
@@ -59,6 +59,9 @@ func (s *svc) Run(ipAdress string, reqChan chan *manager.ServerStreamMessage, au
 
 	var datasets []*manager.Dataset
 	for _, dataPath := range dataPaths {
+		if dataPath == "" {
+			continue
+		}
 		data, err := os.ReadFile(dataPath)
 		if err != nil {
 			s.logger.Error(fmt.Sprintf("failed to read data file: %s", err))


### PR DESCRIPTION
# What type of PR is this?

This is a bug fix because it fixes the computation server failing to run if there is an empty dataset

## What does this do?


This pull request fixes an issue where computations would fail if an empty dataset was provided. The fix involves skipping empty data paths during the computation process. Additionally, tests have been added to verify the correct handling of empty datasets.

- **Bug Fixes**:
    - Fixed issue allowing computation to proceed with an empty dataset by skipping empty data paths.
- **Tests**:
    - Added tests to ensure computations handle empty datasets correctly.

## Which issue(s) does this PR fix/relate to?

No issue

## Have you included tests for your changes?

Tested manually

## Did you document any new/modified feature?

No documentation needed

### Notes

Needed for https://github.com/ultravioletrs/ai/tree/main/burn-algorithms