### PR TITLE
NOISSUE - Start Port Search At Known Port

### DIFF
--- a/manager/service.go
+++ b/manager/service.go
@@ -199,7 +199,6 @@ func getFreePort(minPort, maxPort int) (int, error) {
 
 	var wg sync.WaitGroup
 	portCh := make(chan int, maxPort-minPort+1)
-	errCh := make(chan error, 1)
 
 	for port := minPort; port <= maxPort; port++ {
 		wg.Add(1)
@@ -220,8 +219,8 @@ func getFreePort(minPort, maxPort int) (int, error) {
 	select {
 	case port := <-portCh:
 		return port, nil
-	case err := <-errCh:
-		return 0, err
+	default:
+		return 0, fmt.Errorf("failed to find free port in range %d-%d", minPort, maxPort)
 	}
 }
 


### PR DESCRIPTION
# What type of PR is this?

This is a feature because it adds the functionality of having a reproducible agent URL if the minimum port is not taken

## What does this do?

Refactor the port-checking logic in the getFreePort function by introducing a new helper function checkPortisFree, which streamlines the process of determining if a port is free and removes redundant error handling.

## Which issue(s) does this PR fix/relate to?

No issue

## Have you included tests for your changes?

Tested it manually

## Did you document any new/modified feature?

No documentation needed

### Notes
