### PR TITLE
COCOS-365 - Add IGVM measurement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ CONFIG_DIR ?= /etc/cocos
 SERVICE_NAME ?= cocos-manager
 SERVICE_DIR ?= /etc/systemd/system
 SERVICE_FILE = init/systemd/$(SERVICE_NAME).service
+IGVM_BUILD_SCRIPT := ./scripts/igvmmeasure/igvm.sh
 
 define compile_service
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) \
@@ -27,8 +28,9 @@ endef
 
 all: $(SERVICES)
 
-$(SERVICES):
+$(SERVICES): 
 	$(call compile_service,$@)
+	@if [ "$@" = "cli" ]; then $(MAKE) build-igvm; fi
 
 $(ATTESTATION_POLICY):
 	$(MAKE) -C ./scripts/attestation_policy
@@ -61,3 +63,7 @@ stop:
 install_service:
 	sudo install -m 644 $(SERVICE_FILE) $(SERVICE_DIR)/$(SERVICE_NAME).service
 	sudo systemctl daemon-reload
+
+build-igvm:
+	@echo "Running build script for igvmmeasure..."
+	@$(IGVM_BUILD_SCRIPT)

--- a/cli/README.md
+++ b/cli/README.md
@@ -100,3 +100,22 @@ When defining the manifest dataset and algorithm checksums are required. This ca
 ```bash
 ./build/cocos-cli checksum <path_to_dataset_or_algorithm>
 ```
+
+#### Measure IGVM file
+We assume that our current working directory is the root of the cocos repository, both on the host machine and in the VM.
+
+`igvmmeasure` calculates the launch measurement for an IGVM file and can generate a signed version. It ensures integrity by precomputing the expected launch digest, which can be verified against the attestation report. The tool parses IGVM directives, outputs the measurement as a hex string, or creates a signed file for verification at guest launch.
+
+##### Example
+We measure an IGVM file using our measure command, run:
+
+```bash
+./build/cocos-cli igvmmeasure /path/to/igvm/file
+```
+
+The tool will parse the directives in the IGVM file, calculate the launch measurement, and output the computed digest. If successful, it prints the measurement to standard output.
+
+Here is a sample output
+```
+91c4929bec2d0ecf11a708e09f0a57d7d82208bcba2451564444a4b01c22d047995ca27f9053f86de4e8063e9f810548
+```

--- a/cli/attestation.go
+++ b/cli/attestation.go
@@ -624,6 +624,32 @@ func (cli *CLI) NewValidateAttestationValidationCmd() *cobra.Command {
 	return cmd
 }
 
+func (cli *CLI) NewMeasureCmd(igvmBinaryPath string) *cobra.Command {
+	igvmmeasureCmd := &cobra.Command{
+		Use:   "igvmmeasure <INPUT>",
+		Short: "Measure an IGVM file",
+		Long: `igvmmeasure measures an IGVM file and outputs the calculated measurement.
+			It ensures integrity verification for the IGVM file.`,
+
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("error: No input file provided")
+			}
+
+			inputFile := args[0]
+
+			if err := cli.RunMeasurement(inputFile, igvmBinaryPath); err != nil {
+				return fmt.Errorf("error running measurement: %v", err)
+			}
+
+			return nil
+		},
+	}
+
+	return igvmmeasureCmd
+}
+
 func sevsnpverify(cmd *cobra.Command, args []string) error {
 	cmd.Println("Checking attestation")
 

--- a/cli/attestation_test.go
+++ b/cli/attestation_test.go
@@ -298,7 +298,6 @@ func (m *MockMeasurement) Stop() error {
 }
 
 func TestNewMeasureCmd_RunSuccess(t *testing.T) {
-
 	cliInstance := &CLI{}
 	mockMeasurement := new(MockMeasurement)
 	cliInstance.measurement = mockMeasurement

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -28,7 +28,8 @@ const (
 )
 
 type config struct {
-	LogLevel string `env:"AGENT_LOG_LEVEL" envDefault:"info"`
+	LogLevel       string `env:"AGENT_LOG_LEVEL" envDefault:"info"`
+	IgvmBinaryPath string `env:"IGVM_BINARY_PATH" envDefault:"./build/igvmmeasure"`
 }
 
 func main() {
@@ -136,6 +137,7 @@ func main() {
 
 	// measure.
 	rootCmd.AddCommand(cmd.NewRootCmd())
+	rootCmd.AddCommand(cliSVC.NewMeasureCmd(cfg.IgvmBinaryPath))
 
 	// Flags
 	keysCmd.PersistentFlags().StringVarP(

--- a/pkg/attestation/igvmmeasure/igvmmeasure.go
+++ b/pkg/attestation/igvmmeasure/igvmmeasure.go
@@ -1,0 +1,79 @@
+// Copyright (c) Ultraviolet
+// SPDX-License-Identifier: Apache-2.0
+package igvmmeasure
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+type MeasurementProvider interface {
+	Run(igvmBinaryPath string) error
+	Stop() error
+}
+type IgvmMeasurement struct {
+	pathToFile  string
+	options     []string
+	stderr      io.Writer
+	stdout      io.Writer
+	cmd         *exec.Cmd
+	execCommand func(name string, arg ...string) *exec.Cmd
+}
+
+func NewIgvmMeasurement(pathToFile string, stderr, stdout io.Writer) (*IgvmMeasurement, error) {
+	if pathToFile == "" {
+		return nil, fmt.Errorf("pathToFile cannot be empty")
+	}
+
+	return &IgvmMeasurement{
+		pathToFile:  pathToFile,
+		stderr:      stderr,
+		stdout:      stdout,
+		execCommand: exec.Command,
+	}, nil
+}
+
+func (m *IgvmMeasurement) Run(igvmBinaryPath string) error {
+	binary := igvmBinaryPath
+	args := []string{}
+	args = append(args, m.options...)
+	args = append(args, m.pathToFile)
+	args = append(args, "measure")
+	args = append(args, "-b")
+
+	out, err := m.execCommand(binary, args...).CombinedOutput()
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+	outputString := string(out)
+
+	lines := strings.Split(strings.TrimSpace(outputString), "\n")
+
+	if len(lines) == 1 {
+		outputString = strings.ToLower(outputString)
+		fmt.Print(outputString)
+	} else {
+		return fmt.Errorf("error: %s", outputString)
+	}
+
+	return nil
+}
+
+func (m *IgvmMeasurement) Stop() error {
+	if m.cmd == nil || m.cmd.Process == nil {
+		return fmt.Errorf("no running process to stop")
+	}
+
+	if err := m.cmd.Process.Kill(); err != nil {
+		return fmt.Errorf("failed to stop process: %v", err)
+	}
+
+	return nil
+}
+
+// SetExecCommand allows tests to inject a mock execCommand function.
+func (m *IgvmMeasurement) SetExecCommand(cmdFunc func(name string, arg ...string) *exec.Cmd) {
+	m.execCommand = cmdFunc
+}

--- a/pkg/attestation/igvmmeasure/igvmmeasure_test.go
+++ b/pkg/attestation/igvmmeasure/igvmmeasure_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) Ultraviolet
+// SPDX-License-Identifier: Apache-2.0
+package igvmmeasure
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIgvmMeasurement(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func() *IgvmMeasurement
+		runArgs      string
+		expectErr    bool
+		expectedErr  string
+		expectedIgvm bool
+	}{
+		{
+			name: "NewIgvmMeasurement - Empty pathToFile",
+			setup: func() *IgvmMeasurement {
+				igvm, err := NewIgvmMeasurement("", nil, nil)
+				assert.NotNil(t, err)
+				assert.Nil(t, igvm) // Ensure it's nil
+				return nil          // Explicitly return nil
+			},
+			expectErr:   true,
+			expectedErr: "pathToFile cannot be empty",
+		},
+		{
+			name: "NewIgvmMeasurement - Valid pathToFile",
+			setup: func() *IgvmMeasurement {
+				igvm, err := NewIgvmMeasurement("/valid/path", nil, nil)
+				assert.Nil(t, err)
+				assert.NotNil(t, igvm)
+				return igvm
+			},
+			expectErr:   true,
+			expectedErr: "no running process to stop",
+		},
+		{
+			name: "Stop - No Process",
+			setup: func() *IgvmMeasurement {
+				return &IgvmMeasurement{}
+			},
+			expectErr:   true,
+			expectedErr: "no running process to stop",
+		},
+		{
+			name: "Stop - Success",
+			setup: func() *IgvmMeasurement {
+				process, err := os.StartProcess("/bin/sleep", []string{"sleep", "10"}, &os.ProcAttr{})
+				assert.Nil(t, err)
+
+				defer func() {
+					if err := process.Kill(); err != nil {
+						t.Logf("Failed to kill process: %v", err)
+					}
+				}()
+
+				return &IgvmMeasurement{cmd: &exec.Cmd{Process: process}}
+			},
+		},
+		{
+			name: "Run - Successful Execution",
+			setup: func() *IgvmMeasurement {
+				return &IgvmMeasurement{
+					pathToFile: "/valid/path",
+					execCommand: func(name string, arg ...string) *exec.Cmd {
+						cmd := exec.Command("sh", "-c", "echo 'measurement successful'")
+						return cmd
+					},
+				}
+			},
+			expectErr:   false,
+			expectedErr: "",
+		},
+		{
+			name: "Run - Failure Execution",
+			setup: func() *IgvmMeasurement {
+				return &IgvmMeasurement{
+					pathToFile: "/invalid/path",
+					execCommand: func(name string, arg ...string) *exec.Cmd {
+						cmd := exec.Command("sh", "-c", "echo 'some error occurred\nextra line' && exit 1")
+						return cmd
+					},
+				}
+			},
+			expectErr:   true,
+			expectedErr: "error: some error occurred\nextra line",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			igvm := tc.setup()
+
+			if tc.expectedIgvm {
+				assert.NotNil(t, igvm)
+			}
+
+			if igvm != nil {
+				if strings.Contains(tc.name, "Run") {
+					err := igvm.Run("/mock/igvmBinary")
+					if tc.expectErr {
+						assert.NotNil(t, err)
+						assert.Equal(t, strings.TrimSpace(tc.expectedErr), strings.TrimSpace(err.Error()))
+					} else {
+						assert.Nil(t, err)
+					}
+				} else {
+					err := igvm.Stop()
+					if tc.expectErr {
+						assert.NotNil(t, err)
+						assert.Equal(t, tc.expectedErr, err.Error())
+					} else {
+						assert.Nil(t, err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/scripts/igvmmeasure/igvm.sh
+++ b/scripts/igvmmeasure/igvm.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+REPO_URL="https://github.com/coconut-svsm/svsm.git"
+BUILD_DIR="$(cd "$(dirname "$0")/../.." && pwd)/build"
+
+
+mkdir -p "$BUILD_DIR"
+
+# Define the target directory for cloning inside the build directory
+TARGET_DIR="$BUILD_DIR/svsm"
+SUBDIR="igvmmeasure"
+
+# Clone the repository if it doesn't exist
+if [ -d "$TARGET_DIR" ]; then
+    echo "Repository already exists in $TARGET_DIR. Pulling latest changes..."
+    cd "$TARGET_DIR" && git pull
+else
+    echo "Cloning repository into $TARGET_DIR..."
+    git clone --recurse-submodules "$REPO_URL" "$TARGET_DIR"
+fi
+
+# Ensure submodules are up to date
+cd "$TARGET_DIR"
+git submodule update --init --recursive
+
+# Check if the required subdirectory exists
+if [ -d "$SUBDIR" ]; then
+    echo "Successfully cloned repository and found '$SUBDIR' directory."
+else
+    echo "Error: '$SUBDIR' directory not found inside '$TARGET_DIR'."
+    exit 1
+fi
+
+echo "Building the Rust crate..."
+
+RELEASE=1 make bin/igvmmeasure BUILDDIR="$BUILD_DIR"
+
+mv bin/igvmmeasure "$BUILD_DIR/"
+
+echo "Binary stored in: $BUILD_DIR/igvmmeasure"


### PR DESCRIPTION
<!--

Pull request title should be `COCOS-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/ultravioletrs/cocos/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is a feature because it adds the following functionality: IGVM measurement functionality

## What does this do?
Change the CLI so it calculates the measurement based on the vTPM and OVMF used.

## Which issue(s) does this PR fix/relate to?
- Resolves #365 

## Have you included tests for your changes?

Yes, I have included tests.

## Did you document any new/modified feature?

No, I have not updated the documentation but I will focus on documentation next.

