### PR TITLE
NOISSUE - Enforce binding label check

### DIFF
--- a/pkg/atls/ea/authenticator.go
+++ b/pkg/atls/ea/authenticator.go
@@ -347,18 +347,21 @@ func validateAuthenticator(session *Session, st *tls.ConnectionState, role Role,
 		Context: append([]byte(nil), certMsg.Context...),
 		Chain:   chain,
 	}
+	var verifierPolicy eaattestation.VerificationPolicy
+	// A nil attestation policy is intentional: VerifyPayload then fails closed
+	// for any payload that carries evidence or attestation results without
+	// explicit verifiers being configured.
+	if attPolicy != nil {
+		verifierPolicy = *attPolicy
+	}
+	if !present && verifierPolicy.RequiresAttestation() {
+		return nil, eaattestation.ErrMissingAttestation
+	}
 	if present {
 		res.CMWAttestation = extracted
 		parsed, err := eaattestation.ParsePayload(extracted)
 		if err != nil {
 			return nil, err
-		}
-		var verifierPolicy eaattestation.VerificationPolicy
-		// A nil attestation policy is intentional: VerifyPayload then fails closed
-		// for any payload that carries evidence or attestation results without
-		// explicit verifiers being configured.
-		if attPolicy != nil {
-			verifierPolicy = *attPolicy
 		}
 		verified, err := eaattestation.VerifyPayload(st, eaattestation.ExporterLabelAttestation, certMsg.Context, leaf, parsed, verifierPolicy)
 		if err != nil {

--- a/pkg/atls/ea/authenticator_test.go
+++ b/pkg/atls/ea/authenticator_test.go
@@ -64,6 +64,8 @@ type acceptEvidenceVerifier struct{}
 
 func (acceptEvidenceVerifier) VerifyEvidence(evidence []byte) error { return nil }
 
+const alternateExporterLabel = "Attestation Binding"
+
 func TestDummyAttestationRoundTrip(t *testing.T) {
 	cert := selfSignedCert(t)
 	srv, cli := tlsPair(t, cert)
@@ -124,6 +126,63 @@ func TestDummyAttestationRoundTrip(t *testing.T) {
 	}
 	if res.Attestation == nil || !res.Attestation.BindingVerified || !res.Attestation.EvidenceVerified {
 		t.Fatalf("expected verified attestation result")
+	}
+}
+
+func TestDummyAttestationRoundTripRejectsAlternateExporterLabel(t *testing.T) {
+	cert := selfSignedCert(t)
+	srv, cli := tlsPair(t, cert)
+	defer srv.Close()
+	defer cli.Close()
+
+	ctx, _ := NewRandomContext(16)
+	req := &AuthenticatorRequest{
+		Type:    HandshakeTypeClientCertificateRequest,
+		Context: ctx,
+		Extensions: []Extension{
+			{Type: SignatureAlgorithmsExtensionType, Data: []byte{0x00, 0x02, 0x04, 0x03}},
+			CMWAttestationOfferExtension(),
+		},
+	}
+
+	leaf, _ := x509.ParseCertificate(cert.Certificate[0])
+	srvState := srv.ConnectionState()
+	_, aikPubHash, binding, err := attestation.ComputeBinding(&srvState, alternateExporterLabel, ctx, leaf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloadBytes, err := attestation.MarshalPayload(attestation.Payload{
+		Version:   1,
+		Evidence:  []byte("dummy-attestation-report"),
+		MediaType: "application/eat+cwt",
+		Binder: attestation.AttestationBinder{
+			ExporterLabel: alternateExporterLabel,
+			AIKPubHash:    aikPubHash,
+			Binding:       binding,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ext, err := CMWAttestationDataExtension(payloadBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	auth, err := CreateAuthenticator(&srvState, RoleServer, req, cert, []Extension{ext})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cliState := cli.ConnectionState()
+	roots := x509.NewCertPool()
+	roots.AddCert(leaf)
+
+	_, err = ValidateAuthenticatorWithAttestation(&cliState, RoleServer, req, auth, &x509.VerifyOptions{Roots: roots}, attestation.VerificationPolicy{
+		EvidenceVerifier: acceptEvidenceVerifier{},
+	})
+	if err != attestation.ErrUnexpectedExporterLabel {
+		t.Fatalf("got %v, want %v", err, attestation.ErrUnexpectedExporterLabel)
 	}
 }
 
@@ -196,6 +255,44 @@ func TestAttestationFailsClosedWithoutVerifier(t *testing.T) {
 	cliState := cli.ConnectionState()
 	if _, err := ValidateAuthenticator(&cliState, RoleServer, req, auth, nil); err != attestation.ErrEvidenceVerificationMissing {
 		t.Fatalf("got %v, want %v", err, attestation.ErrEvidenceVerificationMissing)
+	}
+}
+
+func TestValidateAuthenticatorRejectsMissingOfferedAttestation(t *testing.T) {
+	cert := selfSignedCert(t)
+	srv, cli := tlsPair(t, cert)
+	defer srv.Close()
+	defer cli.Close()
+
+	ctx, _ := NewRandomContext(16)
+	req := &AuthenticatorRequest{
+		Type:    HandshakeTypeClientCertificateRequest,
+		Context: ctx,
+		Extensions: []Extension{
+			{Type: SignatureAlgorithmsExtensionType, Data: []byte{0x00, 0x02, 0x04, 0x03}},
+			CMWAttestationOfferExtension(),
+		},
+	}
+
+	srvState := srv.ConnectionState()
+	auth, err := CreateAuthenticator(&srvState, RoleServer, req, cert, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cliState := cli.ConnectionState()
+	roots := x509.NewCertPool()
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots.AddCert(leaf)
+
+	_, err = ValidateAuthenticatorWithAttestation(&cliState, RoleServer, req, auth, &x509.VerifyOptions{Roots: roots}, attestation.VerificationPolicy{
+		EvidenceVerifier: acceptEvidenceVerifier{},
+	})
+	if err != attestation.ErrMissingAttestation {
+		t.Fatalf("got %v, want %v", err, attestation.ErrMissingAttestation)
 	}
 }
 

--- a/pkg/atls/ea/cmw_attestation.go
+++ b/pkg/atls/ea/cmw_attestation.go
@@ -3,19 +3,22 @@
 
 package ea
 
-const CMWAttestationExtensionType uint16 = 0xFF00
+const (
+	CMWAttestationExtensionType uint16 = 0xFF00
+	cmwAttestationLengthBytes          = 2
+)
 
 func CMWAttestationOfferExtension() Extension {
 	return Extension{Type: CMWAttestationExtensionType, Data: nil}
 }
 
 func CMWAttestationDataExtension(cmw []byte) (Extension, error) {
-	if len(cmw) == 0 || len(cmw) > 0xFFFF {
+	if len(cmw) == 0 || len(cmw)+cmwAttestationLengthBytes > 0xFFFF {
 		return Extension{}, ErrInvalidLength
 	}
-	data := make([]byte, 2+len(cmw))
+	data := make([]byte, cmwAttestationLengthBytes+len(cmw))
 	putUint16(data[0:2], uint16(len(cmw)))
-	copy(data[2:], cmw)
+	copy(data[cmwAttestationLengthBytes:], cmw)
 	return Extension{Type: CMWAttestationExtensionType, Data: data}, nil
 }
 

--- a/pkg/atls/eaattestation/binding.go
+++ b/pkg/atls/eaattestation/binding.go
@@ -12,11 +12,9 @@ import (
 )
 
 const (
-	ExporterLabelAttestation        = "Attestation"
-	ExporterLabelAttestationBinding = "Attestation Binding"
+	ExporterLabelAttestation    = "Attestation"
+	ExportedAttestationValueLen = 32
 )
-
-const ExportedAttestationValueLen = 32
 
 var errNotTLS13 = errors.New("attestation: not TLS 1.3")
 

--- a/pkg/atls/eaattestation/binding_test.go
+++ b/pkg/atls/eaattestation/binding_test.go
@@ -17,6 +17,8 @@ import (
 	"time"
 )
 
+const alternateExporterLabel = "Attestation Binding"
+
 type stubEvidenceVerifier struct {
 	called bool
 	err    error
@@ -175,6 +177,37 @@ func TestVerifyPayloadSuccess(t *testing.T) {
 	}
 }
 
+func TestVerifyPayloadRejectsAlternateExporterLabel(t *testing.T) {
+	cert, leaf := makeCert(t)
+	srv, cli := tls13Client(t, cert)
+	defer srv.Close()
+	defer cli.Close()
+
+	st := cli.ConnectionState()
+	ctx := []byte{1, 2, 3, 4}
+	_, aik, binding, err := ComputeBinding(&st, alternateExporterLabel, ctx, leaf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := &Payload{
+		Version:  1,
+		Evidence: []byte("evidence"),
+		Binder: AttestationBinder{
+			ExporterLabel: alternateExporterLabel,
+			AIKPubHash:    aik,
+			Binding:       binding,
+		},
+	}
+
+	_, err = VerifyPayload(&st, ExporterLabelAttestation, ctx, leaf, payload, VerificationPolicy{
+		EvidenceVerifier: &stubEvidenceVerifier{},
+	})
+	if err != ErrUnexpectedExporterLabel {
+		t.Fatalf("got %v, want %v", err, ErrUnexpectedExporterLabel)
+	}
+}
+
 func TestVerifyBinderRejectsMismatch(t *testing.T) {
 	cert, leaf := makeCert(t)
 	srv, cli := tls13Client(t, cert)
@@ -195,5 +228,41 @@ func TestVerifyBinderRejectsMismatch(t *testing.T) {
 	})
 	if err != ErrBindingMismatch {
 		t.Fatalf("got %v, want %v", err, ErrBindingMismatch)
+	}
+}
+
+func TestVerifyPayloadRejectsBadBinderBeforeEvidenceVerification(t *testing.T) {
+	cert, leaf := makeCert(t)
+	srv, cli := tls13Client(t, cert)
+	defer srv.Close()
+	defer cli.Close()
+
+	st := cli.ConnectionState()
+	ctx := []byte{1, 2, 3, 4}
+	_, aik, binding, err := ComputeBinding(&st, ExporterLabelAttestation, ctx, leaf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding[0] ^= 0xff
+
+	ev := &stubEvidenceVerifier{}
+	payload := &Payload{
+		Version:  1,
+		Evidence: []byte("evidence"),
+		Binder: AttestationBinder{
+			ExporterLabel: ExporterLabelAttestation,
+			AIKPubHash:    aik,
+			Binding:       binding,
+		},
+	}
+
+	_, err = VerifyPayload(&st, ExporterLabelAttestation, ctx, leaf, payload, VerificationPolicy{
+		EvidenceVerifier: ev,
+	})
+	if err != ErrBindingMismatch {
+		t.Fatalf("got %v, want %v", err, ErrBindingMismatch)
+	}
+	if ev.called {
+		t.Fatalf("evidence verifier should not be called before binder verification succeeds")
 	}
 }

--- a/pkg/atls/eaattestation/types.go
+++ b/pkg/atls/eaattestation/types.go
@@ -14,6 +14,8 @@ var (
 	ErrMissingBinder               = errors.New("attestation: missing attestation binder")
 	ErrAIKPubHashMismatch          = errors.New("attestation: AIK public key hash mismatch")
 	ErrBindingMismatch             = errors.New("attestation: attestation binding mismatch")
+	ErrUnexpectedExporterLabel     = errors.New("attestation: unexpected exporter label")
+	ErrMissingAttestation          = errors.New("attestation: missing attestation payload")
 	ErrEvidenceVerificationMissing = errors.New("attestation: evidence verifier not configured")
 	ErrResultsVerificationMissing  = errors.New("attestation: attestation results verifier not configured")
 )
@@ -60,6 +62,16 @@ func (p *Payload) NormalizedExporterLabel(defaultLabel string) string {
 		return defaultLabel
 	}
 	return p.Binder.ExporterLabel
+}
+
+func (p *Payload) VerifyExporterLabel(expectedLabel string) error {
+	if p == nil {
+		return ErrMalformedPayload
+	}
+	if p.Binder.ExporterLabel != "" && p.Binder.ExporterLabel != expectedLabel {
+		return ErrUnexpectedExporterLabel
+	}
+	return nil
 }
 
 func MarshalPayload(p Payload) ([]byte, error) {

--- a/pkg/atls/eaattestation/verify.go
+++ b/pkg/atls/eaattestation/verify.go
@@ -22,15 +22,27 @@ type VerificationPolicy struct {
 	ResultsVerifier  ResultsVerifier
 }
 
+func (p VerificationPolicy) RequiresAttestation() bool {
+	return p.EvidenceVerifier != nil || p.ResultsVerifier != nil
+}
+
 func VerifyPayload(st *tls.ConnectionState, defaultLabel string, certificateRequestContext []byte, leaf *x509.Certificate, payload *Payload, policy VerificationPolicy) (*VerifiedPayload, error) {
 	if err := payload.Validate(); err != nil {
+		return nil, err
+	}
+	if err := payload.VerifyExporterLabel(defaultLabel); err != nil {
 		return nil, err
 	}
 
 	verified := &VerifiedPayload{
 		Payload:           payload,
-		UsedExporterLabel: payload.NormalizedExporterLabel(defaultLabel),
+		UsedExporterLabel: defaultLabel,
 	}
+
+	if err := VerifyBinder(st, verified.UsedExporterLabel, certificateRequestContext, leaf, payload.Binder); err != nil {
+		return nil, err
+	}
+	verified.BindingVerified = true
 
 	if len(payload.Evidence) > 0 && policy.EvidenceVerifier != nil {
 		if err := policy.EvidenceVerifier.VerifyEvidence(payload.Evidence); err != nil {
@@ -48,10 +60,6 @@ func VerifyPayload(st *tls.ConnectionState, defaultLabel string, certificateRequ
 	} else if len(payload.AttestationResults) > 0 {
 		return nil, ErrResultsVerificationMissing
 	}
-	if err := VerifyBinder(st, verified.UsedExporterLabel, certificateRequestContext, leaf, payload.Binder); err != nil {
-		return nil, err
-	}
-	verified.BindingVerified = true
 	return verified, nil
 }
 

--- a/pkg/atls/internal_transport/conn.go
+++ b/pkg/atls/internal_transport/conn.go
@@ -168,6 +168,9 @@ func Server(tlsConn *tls.Conn, cfg *ServerConfig) (*Conn, error) {
 	if len(rest) != 0 {
 		return nil, fmt.Errorf("atls: trailing request bytes")
 	}
+	if cfg.BuildLeafExtensions != nil && !ea.RequestPermitsCertificateExtension(&req, ea.CMWAttestationExtensionType) {
+		return nil, fmt.Errorf("atls: cmw_attestation extension not offered")
+	}
 
 	st := tlsConn.ConnectionState()
 	identity, err := resolveIdentity(cfg)


### PR DESCRIPTION
<!--

Pull request title should be `COCOS-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/ultravioletrs/cocos/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?
This is a bug fix because it enforces `ExporterLabelAttestation` check on attestation verification.
 
<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?

<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->
Enforces the server and the client to use `ExporterLabelAttestation` during attestation binding process of attested TLS.
## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

No issue.

## Have you included tests for your changes?

<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->
Yes, I have included tests for my changes.

## Did you document any new/modified feature?

<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->
Documentation is not needed.
### Notes

<!--Please provide any additional information you feel is important.-->
